### PR TITLE
Pie style at initialization and canvas mouseover

### DIFF
--- a/Semicircle.js
+++ b/Semicircle.js
@@ -90,14 +90,14 @@
                 !(startAngle == stopAngle)
             );
         },
-        _containsPoint: function (p, min) {
-            function normalize(angle) {
-	        var newAngle = angle;
-	        while (newAngle <= -Math.PI)
-	            newAngle += 2.0 * Math.PI;
-	        while (newAngle > Math.PI)
-	            newAngle -= 2.0 * Math.PI;
-	        return newAngle;
+        _containsPoint: function (p) {
+            function normalize (angle) {
+	            var newAngle = angle;
+	            while (newAngle <= -Math.PI)
+	                newAngle += 2.0 * Math.PI;
+	            while (newAngle > Math.PI)
+	                newAngle -= 2.0 * Math.PI;
+	            return newAngle;
             }
             var angle = Math.atan2(p.y - this._point.y, p.x - this._point.x);
             var nStart = normalize(this.startAngle());

--- a/Semicircle.js
+++ b/Semicircle.js
@@ -89,6 +89,25 @@
                 !(startAngle === 0 && stopAngle > 359) &&
                 !(startAngle == stopAngle)
             );
+        },
+        _containsPoint: function (p, min) {
+            function normalize(angle) {
+	        var newAngle = angle;
+	        while (newAngle <= -Math.PI)
+	            newAngle += 2.0 * Math.PI;
+	        while (newAngle > Math.PI)
+	            newAngle -= 2.0 * Math.PI;
+	        return newAngle;
+            }
+            var angle = Math.atan2(p.y - this._point.y, p.x - this._point.x);
+            var nStart = normalize(this.startAngle());
+            var nStop = normalize(this.stopAngle());
+            if (nStop <= nStart)
+                nStop += 2.0 * Math.PI;
+            if (angle <= nStart)
+                angle += 2.0 * Math.PI;
+            return nStart < angle && angle <= nStop &&
+                p.distanceTo(this._point) <= this._radius + this._clickTolerance();
         }
     });
 

--- a/Semicircle.js
+++ b/Semicircle.js
@@ -109,8 +109,10 @@
             if (angle <= nStart) {
                 angle += 2.0 * Math.PI;
             }
-            return nStart < angle && angle <= nStop &&
-                p.distanceTo(this._point) <= this._radius + this._clickTolerance();
+            return (
+                nStart < angle && angle <= nStop &&
+                p.distanceTo(this._point) <= this._radius + this._clickTolerance()
+            );
         }
     });
 

--- a/Semicircle.js
+++ b/Semicircle.js
@@ -92,20 +92,23 @@
         },
         _containsPoint: function (p) {
             function normalize (angle) {
-                var newAngle = angle;
-                while (newAngle <= -Math.PI)
-                    newAngle += 2.0 * Math.PI;
-                while (newAngle > Math.PI)
-                    newAngle -= 2.0 * Math.PI;
-                return newAngle;
+                while (angle <= -Math.PI) {
+                    angle += 2.0 * Math.PI;
+                }
+                while (angle > Math.PI) {
+                    angle -= 2.0 * Math.PI;
+                }
+                return angle;
             }
             var angle = Math.atan2(p.y - this._point.y, p.x - this._point.x);
             var nStart = normalize(this.startAngle());
             var nStop = normalize(this.stopAngle());
-            if (nStop <= nStart)
+            if (nStop <= nStart) {
                 nStop += 2.0 * Math.PI;
-            if (angle <= nStart)
+            }
+            if (angle <= nStart) {
                 angle += 2.0 * Math.PI;
+            }
             return nStart < angle && angle <= nStop &&
                 p.distanceTo(this._point) <= this._radius + this._clickTolerance();
         }

--- a/Semicircle.js
+++ b/Semicircle.js
@@ -92,12 +92,12 @@
         },
         _containsPoint: function (p) {
             function normalize (angle) {
-	            var newAngle = angle;
-	            while (newAngle <= -Math.PI)
-	                newAngle += 2.0 * Math.PI;
-	            while (newAngle > Math.PI)
-	                newAngle -= 2.0 * Math.PI;
-	            return newAngle;
+                var newAngle = angle;
+                while (newAngle <= -Math.PI)
+                    newAngle += 2.0 * Math.PI;
+                while (newAngle > Math.PI)
+                    newAngle -= 2.0 * Math.PI;
+                return newAngle;
             }
             var angle = Math.atan2(p.y - this._point.y, p.x - this._point.x);
             var nStart = normalize(this.startAngle());

--- a/piechart/Pie.js
+++ b/piechart/Pie.js
@@ -133,7 +133,11 @@
                     color: this._color(i)
                 }, this.options.sliceOptions);
 
-                var slice = L.circle(this._latlng, options).addTo(this);
+                var slice = L.circle(
+                   this._latlng,
+                   this.options.radius, 
+                   L.Util.extend({}, options, this.options.pathOptions)
+                ).addTo(this);
 
                 if (this.options.labels) {
                     this._createLabel(normalized, this._data[i].label, slice);

--- a/piechart/Pie.js
+++ b/piechart/Pie.js
@@ -133,14 +133,14 @@
                     color: this._color(i)
                 }, this.options.sliceOptions);
 
-                var slice = L.circle(
+                this._data[i].slice = L.circle(
                    this._latlng,
                    this.options.radius, 
                    L.Util.extend({}, options, this.options.pathOptions)
                 ).addTo(this);
 
                 if (this.options.labels) {
-                    this._createLabel(normalized, this._data[i].label, slice);
+                    this._createLabel(normalized, this._data[i].label, this._data[i].slice);
                 }
                 startAngle = stopAngle;
             }

--- a/piechart/Pie.js
+++ b/piechart/Pie.js
@@ -134,9 +134,8 @@
                 }, this.options.sliceOptions);
 
                 this._data[i].slice = L.circle(
-                   this._latlng,
-                   this.options.radius, 
-                   L.Util.extend({}, options, this.options.pathOptions)
+                    this._latlng,
+                    L.Util.extend({}, options, this.options.pathOptions)
                 ).addTo(this);
 
                 if (this.options.labels) {


### PR DESCRIPTION
There is no object field for mouseover, and _containsPoint was not yet implemented (for preferCanvas compatibility). Also, the Pie slices style options were not set at initialization.