### PR TITLE
Make Semicircle.js compatible with Leaflet 1.4.0

### DIFF
--- a/Semicircle.js
+++ b/Semicircle.js
@@ -175,8 +175,6 @@
                 s = (layer._radiusY || r) / r,
                 start = p.rotated(layer.startAngle(), r);
 
-            this._drawnLayers[layer._leaflet_id] = layer;
-
             if (s !== 1) {
                 ctx.save();
                 ctx.scale(1, s);


### PR DESCRIPTION
Hi, I've been using your handy module at work and came across the following error :

>TypeError: this._drawnLayers is undefined

It appear that _drawnLayers has been removed from Leaflet in 1.4.0 ([Changelog](https://github.com/Leaflet/Leaflet/blob/master/CHANGELOG.md), [Pull request](https://github.com/Leaflet/Leaflet/pull/6324)) because it has become useless following a [canvas refactor from nov 2016](https://github.com/Leaflet/Leaflet/commit/4c484462dc4d646cb43adc0585401d28d878330d).

Removing the single and only affectation to this variable in semicircle.js was enough to make it work again.

Regards.

Augustin :fr: 