### PR TITLE
Fix other half of #14, specifically for Canvas rendering

### DIFF
--- a/Semicircle.js
+++ b/Semicircle.js
@@ -169,7 +169,7 @@
 
             if (!this._drawing || layer._empty()) { return; }
 
-            var p = layer._point,
+            var p = layer._map.latLngToLayerPoint(layer._latlng),
                 ctx = this._ctx,
                 r = layer._radius,
                 s = (layer._radiusY || r) / r,


### PR DESCRIPTION
Looks like the PR (#23)  for #14 only addressed the SVG rendering of the Semicircle. We are using the Canvas renderer and noticed the exact issue pointed out in Issue #14. I applied the fix from #23 to the Canvas section and tested. Our issue was resolved as expected.