### PR TITLE
Fixed rounding error on circle.

### DIFF
--- a/Semicircle.js
+++ b/Semicircle.js
@@ -143,7 +143,7 @@
 
             var p = layer._map.latLngToLayerPoint(layer._latlng),
                 r = layer._radius,
-                r2 = Math.round(layer._radiusY || r),
+                r2 = layer._radiusY || r,
                 start = p.rotated(layer.startAngle(), r),
                 end = p.rotated(layer.stopAngle(), r);
 


### PR DESCRIPTION
When the radius is a floating-point number, only the r2 gets rounded and r stays a floating-point value.
This results in a weird ellipse. 

This commit removes the rounding to prevent this from happening.